### PR TITLE
Add committees address to path

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -1,6 +1,6 @@
-import React, { useState, useMemo, useCallback } from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
-import { useAragonApi, usePath, useAppState } from '@aragon/api-react'
+import { useAragonApi } from '@aragon/api-react'
 import {
   Main,
   Button,
@@ -22,48 +22,7 @@ import NoCommittees from './screens/NoCommittees'
 import Committees from './screens/Committees'
 import CommitteeDetails from './screens/CommitteeDetails'
 
-const COMMITTEE_ID_PATH_RE = /^\/committee\/(0x[a-fA-F0-9]{40})\/?$/
-const NO_COMMITTEE_ADDRESS = null
-
-const idFromPath = path => {
-  if (!path) {
-    return NO_COMMITTEE_ADDRESS
-  }
-  const matches = path.match(COMMITTEE_ID_PATH_RE)
-  return matches ? matches[1] : NO_COMMITTEE_ADDRESS
-}
-
-export const useSelectedCommittee = committees => {
-  const [path, requestPath] = usePath()
-  const { appState } = useAragonApi()
-
-  const { isSyncing } = appState
-  // The memoized proposal currently selected.
-  const selectedCommittee = useMemo(() => {
-    const id = idFromPath(path)
-
-    // The `isSyncing` check prevents a proposal to be
-    // selected until the app state is fully ready.
-    if (isSyncing || id === NO_COMMITTEE_ADDRESS) {
-      return null
-    }
-
-    return committees.find(committee => committee.address === id) || null
-  }, [path, isSyncing, committees])
-
-  const selectCommittee = useCallback(
-    committee => {
-      requestPath(
-        committee === NO_COMMITTEE_ADDRESS
-          ? ''
-          : `/committee/${committee.address}/`
-      )
-    },
-    [requestPath]
-  )
-
-  return [selectedCommittee, selectCommittee]
-}
+import useSelectedCommittee from './hooks/useSelectedCommitee'
 
 const App = () => {
   const theme = useTheme()

--- a/app/src/App.js
+++ b/app/src/App.js
@@ -23,14 +23,14 @@ import Committees from './screens/Committees'
 import CommitteeDetails from './screens/CommitteeDetails'
 
 const COMMITTEE_ID_PATH_RE = /^\/committee\/(0x[a-fA-F0-9]{40})\/?$/
-const NO_COMMITTEE_ID = '-1'
+const NO_COMMITTEE_ADDRESS = null
 
 const idFromPath = path => {
   if (!path) {
-    return NO_COMMITTEE_ID
+    return NO_COMMITTEE_ADDRESS
   }
   const matches = path.match(COMMITTEE_ID_PATH_RE)
-  return matches ? matches[1] : NO_COMMITTEE_ID
+  return matches ? matches[1] : NO_COMMITTEE_ADDRESS
 }
 
 export const useSelectedCommittee = committees => {
@@ -44,7 +44,7 @@ export const useSelectedCommittee = committees => {
 
     // The `isSyncing` check prevents a proposal to be
     // selected until the app state is fully ready.
-    if (isSyncing || id === NO_COMMITTEE_ID) {
+    if (isSyncing || id === NO_COMMITTEE_ADDRESS) {
       return null
     }
 
@@ -54,7 +54,7 @@ export const useSelectedCommittee = committees => {
   const selectCommittee = useCallback(
     committee => {
       requestPath(
-        String(committee.address) === NO_COMMITTEE_ID
+        committee === NO_COMMITTEE_ADDRESS
           ? ''
           : `/committee/${committee.address}/`
       )
@@ -71,9 +71,7 @@ const App = () => {
   const { appState } = useAragonApi()
 
   const { committees } = appState
-  const [selectedCommittee, setSelectedCommittee] = useSelectedCommittee(
-    committees
-  )
+  const [selectedCommittee, selectCommittee] = useSelectedCommittee(committees)
 
   const [screenName, setScreenName] = useState('committees')
   const [panel, setPanel] = useState(null)
@@ -127,12 +125,12 @@ const App = () => {
   }
 
   const clickCommitteeHandler = committee => {
-    setSelectedCommittee(committee)
+    selectCommittee(committee)
     setScreenName('info')
   }
 
   const backHandler = () => {
-    setSelectedCommittee(null)
+    selectCommittee(null)
     setScreenName('committees')
   }
 
@@ -186,7 +184,7 @@ const App = () => {
                 committee={selectedCommittee}
                 onBack={backHandler}
                 onChangeTab={changeTabHandler}
-                onDeleteCommittee={() => setSelectedCommittee(null)}
+                onDeleteCommittee={() => selectCommittee(null)}
               />
             ) : (
               <Committees

--- a/app/src/hooks/useSelectedCommitee.js
+++ b/app/src/hooks/useSelectedCommitee.js
@@ -1,0 +1,47 @@
+import { useCallback, useMemo } from 'react'
+import { useAragonApi, usePath } from '@aragon/api-react'
+
+const COMMITTEE_ID_PATH_RE = /^\/committee\/(0x[a-fA-F0-9]{40})\/?$/
+const NO_COMMITTEE_ADDRESS = null
+
+const idFromPath = path => {
+  if (!path) {
+    return NO_COMMITTEE_ADDRESS
+  }
+  const matches = path.match(COMMITTEE_ID_PATH_RE)
+  return matches ? matches[1] : NO_COMMITTEE_ADDRESS
+}
+
+const useSelectedCommittee = committees => {
+  const [path, requestPath] = usePath()
+  const { appState } = useAragonApi()
+
+  const { isSyncing } = appState
+  // The memoized proposal currently selected.
+  const selectedCommittee = useMemo(() => {
+    const id = idFromPath(path)
+
+    // The `isSyncing` check prevents a proposal to be
+    // selected until the app state is fully ready.
+    if (isSyncing || id === NO_COMMITTEE_ADDRESS) {
+      return null
+    }
+
+    return committees.find(committee => committee.address === id) || null
+  }, [path, isSyncing, committees])
+
+  const selectCommittee = useCallback(
+    committee => {
+      requestPath(
+        committee === NO_COMMITTEE_ADDRESS
+          ? ''
+          : `/committee/${committee.address}/`
+      )
+    },
+    [requestPath]
+  )
+
+  return [selectedCommittee, selectCommittee]
+}
+
+export default useSelectedCommittee

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "@aragon/apps-token-manager": "2.1.0",
     "@aragon/apps-vault": "^4.1.0",
     "@aragon/apps-voting": "2.1.0",
-    "@aragon/os": "^4.2.1",
+    "@aragon/os": "^4.3.0",
     "web3-utils": "^1.2.1"
   },
   "devDependencies": {
-    "@aragon/cli": "^6.0.0",
+    "@aragon/cli": "^6.3.3",
     "@aragon/test-helpers": "^2.0.0",
     "babel-eslint": "^10.0.2",
     "cross-env": "^5.2.0",
@@ -29,8 +29,8 @@
     "ethlint": "^1.2.4",
     "ganache-cli": "^6.0.0",
     "prettier": "^1.18.2",
-    "truffle": "4.1.14",
-    "solidity-coverage": "^0.6.4"
+    "solidity-coverage": "^0.6.4",
+    "truffle": "4.1.14"
   },
   "scripts": {
     "start": "npm run start:ipfs",


### PR DESCRIPTION
- When selecting a committee, the path should change to the committee address.
- When coming back from a committee page, the path should just show the /<dao> info
- Resolves issue #21 